### PR TITLE
feat: initial setup with README and implementation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,41 @@
-# @ai-primitives/package-template
+# esbuild-mdxld
 
-[![npm version](https://badge.fury.io/js/%40ai-primitives%2Fpackage-template.svg)](https://www.npmjs.com/package/@ai-primitives/package-template)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-A modern TypeScript package template with Vitest, Prettier, ESLint, and semantic versioning.
+ESBuild plugin for MDX with Linked Data Context and URI/HTTP imports. Extends @mdx-js/esbuild with YAML-LD support and remote content imports.
 
 ## Features
-
-- 🚀 TypeScript for type safety and modern JavaScript features
-- ⚡️ Vitest for fast, modern testing
-- 🎨 Prettier for consistent code formatting
-- 🔍 ESLint for code quality
-- 📦 Semantic versioning with automated releases
-- 🔄 GitHub Actions for CI/CD
+- 🔗 Full YAML-LD support in frontmatter
+- 📡 URI/HTTP imports for remote content
+- 🌐 WASM support via esbuild-mdxld/wasm
+- 🔄 Integrated with remark-mdxld for enrichment
+- 📦 Type-safe parsing and validation
 
 ## Installation
-
 ```bash
-pnpm add @ai-primitives/package-template
+npm install esbuild-mdxld
+# or
+pnpm add esbuild-mdxld
 ```
 
 ## Usage
-
 ```typescript
-import { add } from '@ai-primitives/package-template'
+import mdxld from 'esbuild-mdxld'
+import * as esbuild from 'esbuild'
 
-const result = add(1, 2) // returns 3
+await esbuild.build({
+  entryPoints: ['index.mdx'],
+  outfile: 'out.js',
+  plugins: [mdxld({
+    // Options from @mdx-js/esbuild
+    jsxImportSource: '@mdx-js/react',
+    // Additional mdxld options
+    validateRequired: true,
+    preferDollarPrefix: true
+  })]
+})
 ```
 
-## Development
-
-```bash
-# Install dependencies
-pnpm install
-
-# Run tests
-pnpm test
-
-# Run tests in watch mode
-pnpm test:watch
-
-# Build the package
-pnpm build
-
-# Lint the code
-pnpm lint
-
-# Format the code
-pnpm format
+## WASM Usage
+```typescript
+import mdxld from 'esbuild-mdxld/wasm'
+// ... same usage as above
 ```
-
-## Contributing
-
-Please read our [Contributing Guide](./CONTRIBUTING.md) to learn about our development process and how to propose bugfixes and improvements.
-
-## License
-
-MIT © [AI Primitives](https://mdx.org.ai)
-
-## Dependencies
-
-This package uses the following key dependencies:
-
-- TypeScript for static typing
-- Vitest for testing
-- ESLint for linting
-- Prettier for code formatting

--- a/TODO.md
+++ b/TODO.md
@@ -1,44 +1,35 @@
-# Project Status and Tasks
+# Implementation Plan
 
-## Setup and Configuration
+## Core Plugin Implementation
+- [ ] Set up plugin structure extending @mdx-js/esbuild
+- [ ] Integrate mdxld for YAML-LD parsing
+- [ ] Add remark-mdxld for MDX enrichment
+- [ ] Implement URI/HTTP import resolution
+  - [ ] Add onResolve hook for http(s):// imports
+  - [ ] Add onLoad hook to fetch remote content
+  - [ ] Cache remote content for performance
+  - [ ] Handle error cases and timeouts
 
-- [x] Initialize package with TypeScript configuration
-- [x] Set up Vitest for testing
-- [x] Configure ESLint and Prettier
-- [x] Set up basic project structure
-- [x] Create placeholder implementation and tests
-- [x] Configure package.json with proper metadata
-
-## Implementation
-- [x] Basic package structure
-  - [x] TypeScript configuration
-  - [x] Testing setup with Vitest
-  - [x] ESLint and Prettier configuration
-- [x] CLI functionality
-  - [x] Basic command-line interface
-  - [x] Version and help commands
-- [ ] Advanced features
-  - [ ] Additional CLI commands
-  - [ ] Extended test coverage
-  - [ ] Documentation examples
+## WASM Support
+- [ ] Create separate entry point for WASM
+- [ ] Implement WASM-specific plugin wrapper
+- [ ] Add WASM build configuration
+- [ ] Test WASM functionality
 
 ## Documentation
-
-- [x] Create README with badges and usage instructions
-- [ ] Complete CONTRIBUTING.md guide
 - [ ] Add API documentation
-- [ ] Add examples directory with usage examples
+- [ ] Add examples for common use cases
+- [ ] Document configuration options
+- [ ] Add contributing guidelines
 
-## CI/CD
-
-- [ ] Set up GitHub Actions workflow
-- [ ] Configure semantic-release
-- [ ] Add test coverage reporting
-- [ ] Set up automated npm publishing
+## Testing
+- [ ] Unit tests for core functionality
+- [ ] Integration tests with example MDX files
+- [ ] WASM-specific tests
+- [ ] Remote content import tests
 
 ## Future Enhancements
-
-- [ ] Add more comprehensive examples
-- [ ] Add changelog generation
-- [ ] Add pull request template
-- [ ] Add issue templates
+- [ ] Add support for custom remote content resolvers
+- [ ] Implement caching strategies for remote content
+- [ ] Add validation for remote content schemas
+- [ ] Support for custom YAML-LD contexts

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "package-template",
+  "name": "esbuild-mdxld",
   "version": "0.1.0",
-  "description": "A modern TypeScript package template with Vitest, Prettier, ESLint, and semantic versioning",
+  "description": "ESBuild plugin for MDX with Linked Data Context and URI/HTTP imports",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "package-template": "bin/cli.js"
+  "exports": {
+    ".": "./dist/index.js",
+    "./wasm": "./dist/wasm.js"
   },
   "files": [
-    "dist",
-    "bin"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",
@@ -22,20 +22,27 @@
     "prepublishOnly": "pnpm run build"
   },
   "keywords": [
-    "typescript",
-    "template",
-    "package",
-    "cli"
+    "esbuild",
+    "mdx",
+    "mdxld",
+    "plugin",
+    "linked-data",
+    "yaml-ld"
   ],
   "author": "AI Primitives",
   "license": "MIT",
   "homepage": "https://mdx.org.ai",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ai-primitives/package-template.git"
+    "url": "git+https://github.com/ai-primitives/esbuild-mdxld.git"
   },
   "bugs": {
-    "url": "https://github.com/ai-primitives/package-template/issues"
+    "url": "https://github.com/ai-primitives/esbuild-mdxld/issues"
+  },
+  "dependencies": {
+    "@mdx-js/esbuild": "^3.0.0",
+    "mdxld": "^0.1.0",
+    "remark-mdxld": "^0.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
# feat: initial setup with README and implementation plan

Initial setup for esbuild-mdxld plugin:
- Update package.json with correct metadata and dependencies
- Create README with installation and usage instructions
- Create TODO.md with implementation plan

Link to Devin run: https://app.devin.ai/sessions/1ee7f1e9101543018f74b8fa1dc6b55c
